### PR TITLE
Fix detecting online when only a few logs exist

### DIFF
--- a/elastalert_extensions/ruletypes.py
+++ b/elastalert_extensions/ruletypes.py
@@ -238,13 +238,15 @@ class ProfiledThresholdRule(ProfiledFrequencyRule):
         if self.first_event.get(key) is None:
             self.first_event[key] = most_recent_ts
 
-        # Don't check for matches until timeframe has elapsed
-        if most_recent_ts - self.first_event[key] < self.timeframe(key):
-            return
-
         # Match if, after removing old events, we hit num_events
         count = self.occurrences[key].count()
         status = self.below if count < self.rules['threshold'] else self.above
+
+        # Don't set to `below` until timeframe has elapsedq
+        # This is copied from FlatlineRule, so only applies to below
+        if status == self.below and \
+                most_recent_ts - self.first_event[key] < self.timeframe(key):
+            return
 
         if status != self._get_status(key):
             # Do a deep-copy, otherwise we lose the datetime type

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert-extensions',
-    version='0.1.5',
+    version='0.1.6',
     description='Customized Elastalert rule typs and alerts',
     author='Chun-da Chen',
     author_email='capitalm@thingnario.com',


### PR DESCRIPTION
The safe guard `most_recent_ts - self.first_event[key] < self.timeframe(key)`
is copied from FlatlineRule, so it only applies to `below` detection.